### PR TITLE
Fix generic function map-column-as argument order

### DIFF
--- a/lib/table.lisp
+++ b/lib/table.lisp
@@ -307,7 +307,7 @@ number or a column name. Return the results."))
     ;; table
     ))
 
-(defgeneric map-column-as (column type function table)
+(defgeneric map-column-as (type column function table)
   (:documentation
    "Call ‘function’ with the value for row of ‘column’ in ‘table’. ‘column’ can
 be a number or a column name. Return the results as a ‘type’."))


### PR DESCRIPTION
Hi, your project is very awesome!

Perhaps you would consider this PR: I ran into a problem with `table:map-column-as`. I think the argument order on the `defgeneric` should be switch to match the `defmethod`.