### PR TITLE
Export unsetenv for unix, add it for ms

### DIFF
--- a/opsys/ms/environmental.lisp
+++ b/opsys/ms/environmental.lisp
@@ -95,6 +95,11 @@ NIL, unset the VAR, using unsetenv."
 (defsetf env set-environment-variable
     "Set the environtment variable named VAR to the string VALUE.")
 
+(defun unsetenv (var)
+  "Remove the environtment variable named VAR."
+  (declare (type string-designator var))
+  (set-environment-variable var nil))
+
 (defcstruct foreign-processor-arch
   (processor-architecture WORD)
   (reserved WORD))

--- a/opsys/ms/package.lisp
+++ b/opsys/ms/package.lisp
@@ -37,6 +37,7 @@
    #:environment
    #:environment-variable
    #:env
+   #:unsetenv
    #:memory-page-size
    #:processor-count
    #:system-info-names

--- a/opsys/package.lisp
+++ b/opsys/package.lisp
@@ -25,6 +25,7 @@
    #:environment
    #:environment-variable
    #:env
+   #:unsetenv
    #:lisp-args
    #:memory-page-size
    #:processor-count


### PR DESCRIPTION
Hi, I was trying to port the shell integration for for ASDF (a tools versioning thing – big pile of bash, don't look) and needed an unsetenv function. It was already there for unix, just not exported and needed to be added for ms. I don't have the a windows to test though...